### PR TITLE
Make model.Generator serializable to TorchScript

### DIFF
--- a/model.py
+++ b/model.py
@@ -87,7 +87,7 @@ class Generator(nn.Module):
             nn.Tanh()
         )
         
-    def forward(self, input, align_corners=True):
+    def forward(self, input, align_corners: bool = True):
         out = self.block_a(input)
         half_size = out.size()[-2:]
         out = self.block_b(out)
@@ -96,13 +96,13 @@ class Generator(nn.Module):
         if align_corners:
             out = F.interpolate(out, half_size, mode="bilinear", align_corners=True)
         else:
-            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
+            out = F.interpolate(out, scale_factor=2., mode="bilinear", align_corners=False)
         out = self.block_d(out)
 
         if align_corners:
             out = F.interpolate(out, input.size()[-2:], mode="bilinear", align_corners=True)
         else:
-            out = F.interpolate(out, scale_factor=2, mode="bilinear", align_corners=False)
+            out = F.interpolate(out, scale_factor=2., mode="bilinear", align_corners=False)
         out = self.block_e(out)
 
         out = self.out_layer(out)


### PR DESCRIPTION
Test command to serialize the model:

  python -c 'import torch ; import model ; m = model.Generator() ; s = torch.jit.script(m)'

Before this change there were two errors during serialization. First, the
interpolate call expects a float rather than an integer:

  RuntimeError: Arguments for call are not valid.

Second was the types on the forward call:

  RuntimeError: Expected a default value of type Tensor (inferred) on parameter "align_corners".Because "align_corners" was not annotated with an explicit type it is assumed to be type 'Tensor'.: